### PR TITLE
bier-ospfv3: Add sample topology with the FastClick BIER data-plane

### DIFF
--- a/bier-ospfv3/Dockerfile
+++ b/bier-ospfv3/Dockerfile
@@ -1,0 +1,12 @@
+FROM debian:bookworm-slim AS fastclick-builder
+RUN apt update && apt install -y git libmicrohttpd-dev clang make autoconf
+WORKDIR /build
+RUN git clone https://github.com/nrybowski/fastclick.git
+WORKDIR /build/fastclick
+RUN git checkout bier
+RUN autoconf && ./configure --enable-ip6 --enable-bier && make -j$(nproc)
+
+# Make sure to compile holod with the `fastclick` feature flag!
+FROM ghcr.io/holo-routing/holo:latest
+RUN apt update && apt install -y curl libmicrohttpd-dev tshark
+COPY --from=fastclick-builder /build/fastclick/userlevel/click /bin/click

--- a/bier-ospfv3/README.md
+++ b/bier-ospfv3/README.md
@@ -1,0 +1,111 @@
+# BIER sample configuration for OSPFv3 and FastClick
+
+This small topology provides an example for configuring the BIER control-plane in OSPFv3 and a BIER data-plane in FastClick.
+
+The FastClick router configures IPv6 Neighbor Discovery to allow IPv6 forwarding, in addition of the BIER lookup table.
+
+## Build
+
+An additional Dockerfile is provided to build the `click` binary embedding the BIER lookup table.
+
+Run the following command to build the additional image:
+
+```console
+$ docker build -t holo-runner .
+```
+
+> Make sure to compile holod with the `fastclick` feature flag beforehand!
+
+## Usage
+
+You can dump the content of the BIER Routing Information Bases (BIRTs) with the following command:
+
+```console
+$ docker exec -it clab-bier-ospfv3-r1 holo-cli -c "sh state xpath /ietf-routing:routing/holo-routing:birts"
+```
+
+Here is the expected content for the provided topology:
+
+```json
+{
+  "ietf-routing:routing": {
+    "holo-routing:birts": {
+      "birt": [
+        {
+          "sub-domain-id": 0,
+          "bfr-id": [
+            {
+              "bfr-id": 1,
+              "birt-entry": [
+                {
+                  "bsl": 3,
+                  "bfr-prefix": "fc00::",
+                  "bfr-nbr": "fe80::a8c1:abff:fee4:2e75"
+                }
+              ]
+            },
+            {
+              "bfr-id": 3,
+              "birt-entry": [
+                {
+                  "bsl": 3,
+                  "bfr-prefix": "fc00::2",
+                  "bfr-nbr": "fe80::a8c1:abff:fe9b:703b"
+                }
+              ]
+            },
+            {
+              "bfr-id": 4,
+              "birt-entry": [
+                {
+                  "bsl": 3,
+                  "bfr-prefix": "fc00::3",
+                  "bfr-nbr": "fe80::a8c1:abff:fe0f:b9a"
+                }
+              ]
+            },
+            {
+              "bfr-id": 5,
+              "birt-entry": [
+                {
+                  "bsl": 3,
+                  "bfr-prefix": "fc00::4",
+                  "bfr-nbr": "fe80::a8c1:abff:fe9b:703b"
+                }
+              ]
+            },
+            {
+              "bfr-id": 6,
+              "birt-entry": [
+                {
+                  "bsl": 3,
+                  "bfr-prefix": "fc00::5",
+                  "bfr-nbr": "fe80::a8c1:abff:fe9b:703b"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  }
+}
+```
+
+You can also dump the content of the BIER Forwarding Table (BIFT) in click with the following command:
+
+```console
+$ docker exec -it clab-bier-ospfv3-r1 curl localhost/bift0/table 
+```
+
+Here is the expected content for the provided topology:
+
+```json
+# Active routes
+# BFR-id   BFR-prefix     F-BM    Nexthop    Ifindex
+    1    fc00::      0      fe80::a8c1:abff:fee4:2e75      254      eth0
+    3    fc00::2      2,4-5      fe80::a8c1:abff:fe9b:703b      268      eth1
+    4    fc00::3      3      fe80::a8c1:abff:fe0f:b9a      257      eth3
+    5    fc00::4      2,4-5      fe80::a8c1:abff:fe9b:703b      268      eth1
+    6    fc00::5      2,4-5      fe80::a8c1:abff:fe9b:703b      268      eth1
+```

--- a/bier-ospfv3/click/r0.click
+++ b/bier-ospfv3/click/r0.click
@@ -1,0 +1,49 @@
+cfg :: HTTPServer;
+
+bift0 :: LookupBierTable(BIFT_ID 0x01234, BFR_ID 1, IFACE eth0:2, IFACE eth1:3);
+bift1 :: LookupBierTable(BIFT_ID 0x5, BFR_ID 1, IFACE eth0:2, IFACE eth1:3);
+
+lo :: FromDevice(lo, SNIFFER false, PROMISC true);
+eth0 :: FromDevice(eth0, SNIFFER false, PROMISC true);
+eth1 :: FromDevice(eth1, SNIFFER false, PROMISC true);
+lo_out :: Queue -> ToDevice(lo);
+eth0_out :: Queue -> ToDevice(eth0);
+eth1_out :: Queue -> ToDevice(eth1);
+
+eth0_nds :: IP6NDSolicitor(fc00::, aa:c1:ab:07:ba:00);
+ndadv_eth0 :: IP6NDAdvertiser(fc00::/128 aa:c1:ab:07:ba:00);
+eth1_nds :: IP6NDSolicitor(fc00::, aa:c1:ab:07:ba:01);
+ndadv_eth1 :: IP6NDAdvertiser(fc00::/128 aa:c1:ab:07:ba:01);
+
+eth0 -> ndp_cl_eth0 :: Classifier(12/86dd 20/3aff 54/87, 12/86dd 20/3aff 54/88, 12/86dd);
+// Received NDP Solicitation, reply with NDP Advertisement
+ndp_cl_eth0[0] -> ndadv_eth0 -> eth0_out;
+// Received NDP Advertisement, save the mapping
+ndp_cl_eth0[1] -> [1] eth0_nds;
+
+eth1 -> ndp_cl_eth1 :: Classifier(12/86dd 20/3aff 54/87, 12/86dd 20/3aff 54/88, 12/86dd);
+ndp_cl_eth1[0] -> ndadv_eth1 -> eth1_out;
+ndp_cl_eth1[1] -> [1] eth1_nds;
+
+// Check BIER packet validity then send it to the correct BIFT
+lo, ndp_cl_eth0[2], ndp_cl_eth1[2]
+	-> CheckIP6Header(OFFSET 14)
+	-> CheckBIERin6Header
+	-> CheckBIERHeader
+	-> IP6Print("here", CONTENTS true, NBYTES 2000)
+	-> Strip(14)
+	-> Print
+	-> bift_cl :: Classifier(
+		40/01234?%fffff0,
+		40/05,
+		-
+	);
+
+bift_cl[0] -> bift0;
+bift_cl[1] -> bift1;
+bift_cl[2] -> Print("Unknown BIFT id") -> Discard;
+
+bift0[0], bift1[0] -> Print("drop") -> Discard;
+bift0[1], bift1[1] -> Print("lo") -> lo_out;
+bift0[2], bift1[2] -> [0] eth0_nds [0] -> Print("eth0") -> eth0_out;
+bift0[3], bift1[3] -> [0] eth1_nds [0] -> Print("eth1") -> eth1_out;

--- a/bier-ospfv3/click/r1.click
+++ b/bier-ospfv3/click/r1.click
@@ -1,0 +1,57 @@
+cfg :: HTTPServer;
+
+bift0 :: LookupBierTable(BIFT_ID 0x01234, BFR_ID 2, IFACE eth0:2, IFACE eth1:3, IFACE eth2:4, IFACE eth3:5);
+
+lo :: FromDevice(lo, SNIFFER false, PROMISC true);
+eth0 :: FromDevice(eth0, SNIFFER false, PROMISC true);
+eth1 :: FromDevice(eth1, SNIFFER false, PROMISC true);
+eth2 :: FromDevice(eth2, SNIFFER false, PROMISC true);
+eth3 :: FromDevice(eth3, SNIFFER false, PROMISC true);
+lo_out :: Queue -> ToDevice(lo);
+eth0_out :: Queue -> ToDevice(eth0);
+eth1_out :: Queue -> ToDevice(eth1);
+eth2_out :: Queue -> ToDevice(eth2);
+eth3_out :: Queue -> ToDevice(eth3);
+
+eth0_nds :: IP6NDSolicitor(fc00::1, aa:c1:ab:07:ba:02);
+ndadv_eth0 :: IP6NDAdvertiser(fc00::1/128 aa:c1:ab:07:ba:02);
+eth1_nds :: IP6NDSolicitor(fc00::1, aa:c1:ab:07:ba:03);
+ndadv_eth1 :: IP6NDAdvertiser(fc00::1/128 aa:c1:ab:07:ba:03);
+eth2_nds :: IP6NDSolicitor(fc00::1, aa:c1:ab:07:ba:04);
+ndadv_eth2 :: IP6NDAdvertiser(fc00::1/128 aa:c1:ab:07:ba:04);
+eth3_nds :: IP6NDSolicitor(fc00::1, aa:c1:ab:07:ba:05);
+ndadv_eth3 :: IP6NDAdvertiser(fc00::1/128 aa:c1:ab:07:ba:05);
+
+eth0 -> ndp_cl_eth0 :: Classifier(12/86dd 20/3aff 54/87, 12/86dd 20/3aff 54/88, 12/86dd);
+// Received NDP Solicitation, reply with NDP Advertisement
+ndp_cl_eth0[0] -> Print("NDP ADV eth0") -> ndadv_eth0 -> eth0_out;
+// Received NDP Advertisement, save the mapping
+ndp_cl_eth0[1] -> [1] eth0_nds;
+
+eth1 -> ndp_cl_eth1 :: Classifier(12/86dd 20/3aff 54/87, 12/86dd 20/3aff 54/88, 12/86dd);
+ndp_cl_eth1[0] -> Print("NDP ADV eth1") -> ndadv_eth1 -> eth1_out;
+ndp_cl_eth1[1] -> [1] eth1_nds;
+
+eth2 -> ndp_cl_eth2 :: Classifier(12/86dd 20/3aff 54/87, 12/86dd 20/3aff 54/88, 12/86dd);
+ndp_cl_eth2[0] -> Print("NDP ADV eth1") -> ndadv_eth2 -> eth2_out;
+ndp_cl_eth2[1] -> [1] eth2_nds;
+
+eth3 -> ndp_cl_eth3 :: Classifier(12/86dd 20/3aff 54/87, 12/86dd 20/3aff 54/88, 12/86dd);
+ndp_cl_eth3[0] -> Print("NDP ADV eth1") -> ndadv_eth3 -> eth3_out;
+ndp_cl_eth3[1] -> [1] eth3_nds;
+
+lo, ndp_cl_eth0[2], ndp_cl_eth1[2], ndp_cl_eth2[2], ndp_cl_eth3[2]
+    ->  CheckIP6Header(OFFSET 14)
+	-> CheckBIERin6Header
+	-> CheckBIERHeader
+	-> IP6Print(CONTENTS true)
+	-> Strip(14)
+	-> Print
+	-> bift0;
+
+bift0[0] -> Print("drop") -> Discard;
+bift0[1] -> Print("lo") -> lo_out;
+bift0[2] -> [0] eth0_nds [0] -> Print("eth0") -> eth0_out;
+bift0[3] -> [0] eth1_nds [0] -> Print("eth1") -> eth1_out;
+bift0[4] -> [0] eth2_nds [0] -> Print("eth2") -> eth2_out;
+bift0[5] -> [0] eth3_nds [0] -> Print("eth3") -> eth3_out;

--- a/bier-ospfv3/click/r2.click
+++ b/bier-ospfv3/click/r2.click
@@ -1,0 +1,57 @@
+cfg :: HTTPServer;
+
+bift0 :: LookupBierTable(BIFT_ID 0x01234, BFR_ID 3, IFACE eth0:2, IFACE eth1:3, IFACE eth2:4, IFACE eth3:5);
+
+lo :: FromDevice(lo, SNIFFER false, PROMISC true);
+eth0 :: FromDevice(eth0, SNIFFER false, PROMISC true);
+eth1 :: FromDevice(eth1, SNIFFER false, PROMISC true);
+eth2 :: FromDevice(eth2, SNIFFER false, PROMISC true);
+eth3 :: FromDevice(eth3, SNIFFER false, PROMISC true);
+lo_out :: Queue -> ToDevice(lo);
+eth0_out :: Queue -> ToDevice(eth0);
+eth1_out :: Queue -> ToDevice(eth1);
+eth2_out :: Queue -> ToDevice(eth2);
+eth3_out :: Queue -> ToDevice(eth3);
+
+eth0_nds :: IP6NDSolicitor(fc00::2, aa:c1:ab:07:ba:06);
+ndadv_eth0 :: IP6NDAdvertiser(fc00::2/128 aa:c1:ab:07:ba:06);
+eth1_nds :: IP6NDSolicitor(fc00::2, aa:c1:ab:07:ba:07);
+ndadv_eth1 :: IP6NDAdvertiser(fc00::2/128 aa:c1:ab:07:ba:07);
+eth2_nds :: IP6NDSolicitor(fc00::2, aa:c1:ab:07:ba:08);
+ndadv_eth2 :: IP6NDAdvertiser(fc00::2/128 aa:c1:ab:07:ba:08);
+eth3_nds :: IP6NDSolicitor(fc00::2, aa:c1:ab:07:ba:09);
+ndadv_eth4 :: IP6NDAdvertiser(fc00::2/128 aa:c1:ab:07:ba:09);
+
+eth0 -> ndp_cl_eth0 :: Classifier(12/86dd 20/3aff 54/87, 12/86dd 20/3aff 54/88, 12/86dd);
+// Received NDP Solicitation, reply with NDP Advertisement
+ndp_cl_eth0[0] -> ndadv_eth0 -> eth0_out;
+// Received NDP Advertisement, save the mapping
+ndp_cl_eth0[1] -> [1] eth0_nds;
+
+eth1 -> ndp_cl_eth1 :: Classifier(12/86dd 20/3aff 54/87, 12/86dd 20/3aff 54/88, 12/86dd);
+ndp_cl_eth1[0] -> ndadv_eth1 -> eth1_out;
+ndp_cl_eth1[1] -> [1] eth1_nds;
+
+eth2 -> ndp_cl_eth2 :: Classifier(12/86dd 20/3aff 54/87, 12/86dd 20/3aff 54/88, 12/86dd);
+ndp_cl_eth2[0] -> ndadv_eth2 -> eth2_out;
+ndp_cl_eth2[1] -> [1] eth2_nds;
+
+eth3 -> ndp_cl_eth3 :: Classifier(12/86dd 20/3aff 54/87, 12/86dd 20/3aff 54/88, 12/86dd);
+ndp_cl_eth3[0] -> ndadv_eth3 -> eth3_out;
+ndp_cl_eth3[1] -> [1] eth3_nds;
+
+lo, ndp_cl_eth0[2], ndp_cl_eth1[2], ndp_cl_eth2[2], ndp_cl_eth3[2]
+    ->  CheckIP6Header(OFFSET 14)
+	-> CheckBIERin6Header
+	-> CheckBIERHeader
+	-> IP6Print(CONTENTS true)
+	-> Strip(14)
+	-> Print
+	-> bift0;
+
+bift0[0] -> Print("drop") -> Discard;
+bift0[1] -> Print("lo") -> lo_out;
+bift0[2] -> [0] eth0_nds [0] -> Print("eth0") -> eth0_out;
+bift0[3] -> [0] eth1_nds [0] -> Print("eth1") -> eth1_out;
+bift0[4] -> [0] eth2_nds [0] -> Print("eth2") -> eth2_out;
+bift0[5] -> [0] eth3_nds [0] -> Print("eth3") -> eth3_out;

--- a/bier-ospfv3/click/r3.click
+++ b/bier-ospfv3/click/r3.click
@@ -1,0 +1,38 @@
+cfg :: HTTPServer;
+
+bift0 :: LookupBierTable(BIFT_ID 0x01234, BFR_ID 4, IFACE eth0:2, IFACE eth1:3);
+
+lo :: FromDevice(lo, SNIFFER false, PROMISC true);
+eth0 :: FromDevice(eth0, SNIFFER false, PROMISC true);
+eth1 :: FromDevice(eth1, SNIFFER false, PROMISC true);
+lo_out :: Queue -> ToDevice(lo);
+eth1_out :: Queue -> ToDevice(eth1);
+
+eth1_nds :: IP6NDSolicitor(fc00::3, aa:c1:ab:07:ba:0a);
+ndadv_eth1 :: IP6NDAdvertiser(fc00::3/128 aa:c1:ab:07:ba:0a);
+eth2_nds :: IP6NDSolicitor(fc00::3, aa:c1:ab:07:ba:0b);
+ndadv_eth2 :: IP6NDAdvertiser(fc00::3/128 aa:c1:ab:07:ba:0b);
+
+eth0 -> ndp_cl_eth0 :: Classifier(12/86dd 20/3aff 54/87, 12/86dd 20/3aff 54/88, 12/86dd);
+// Received NDP Solicitation, reply with NDP Advertisement
+ndp_cl_eth0[0] -> ndadv_eth0 -> eth0_out;
+// Received NDP Advertisement, save the mapping
+ndp_cl_eth0[1] -> [1] eth0_nds;
+
+eth1 -> ndp_cl_eth1 :: Classifier(12/86dd 20/3aff 54/87, 12/86dd 20/3aff 54/88, 12/86dd);
+ndp_cl_eth1[0] -> ndadv_eth& -> eth1_out;
+ndp_cl_eth1[1] -> [1] eth1_nds;
+
+lo, ndp_cl_eth0[2], ndp_cl_eth1[2]
+	->  CheckIP6Header(OFFSET 14)
+	-> CheckBIERin6Header
+	-> CheckBIERHeader
+	-> IP6Print(CONTENTS true)
+	-> Strip(14)
+	-> Print
+	-> bift0;
+
+bift0[0] -> Print("drop") -> Discard;
+bift0[1] -> Print("lo") -> lo_out;
+bift0[2] -> [0] eth0_nds [0] -> Print("eth0") -> eth0_out;
+bift0[3] -> [0] eth1_nds [0] -> Print("eth1") -> eth1_out;

--- a/bier-ospfv3/click/r4.click
+++ b/bier-ospfv3/click/r4.click
@@ -1,0 +1,39 @@
+cfg :: HTTPServer;
+
+bift0 :: LookupBierTable(BIFT_ID 0x01234, BFR_ID 5, IFACE eth0:2, IFACE eth1:3);
+
+lo :: FromDevice(lo, SNIFFER false, PROMISC true);
+eth0 :: FromDevice(eth0, SNIFFER false, PROMISC true);
+eth1 :: FromDevice(eth1, SNIFFER false, PROMISC true);
+lo_out :: Queue -> ToDevice(lo);
+eth0_out :: Queue -> ToDevice(eth0);
+eth1_out :: Queue -> ToDevice(eth1);
+
+eth0_nds :: IP6NDSolicitor(fc00::4, aa:c1:ab:07:ba:0c);
+ndadv_eth0 :: IP6NDAdvertiser(fc00::4/128 aa:c1:ab:07:ba:0c);
+eth1_nds :: IP6NDSolicitor(fc00::4, aa:c1:ab:07:ba:0d);
+ndadv_eth1 :: IP6NDAdvertiser(fc00::4/128 aa:c1:ab:07:ba:0d);
+
+eth0 -> ndp_cl_eth0 :: Classifier(12/86dd 20/3aff 54/87, 12/86dd 20/3aff 54/88, 12/86dd);
+// Received NDP Solicitation, reply with NDP Advertisement
+ndp_cl_eth0[0] -> ndadv_eth0 -> eth0_out;
+// Received NDP Advertisement, save the mapping
+ndp_cl_eth0[1] -> [1] eth0_nds;
+
+eth1 -> ndp_cl_eth1 :: Classifier(12/86dd 20/3aff 54/87, 12/86dd 20/3aff 54/88, 12/86dd);
+ndp_cl_eth1[0] -> ndadv_eth1 -> eth1_out;
+ndp_cl_eth1[1] -> [1] eth1_nds;
+
+lo, ndp_cl_eth0[2], ndp_cl_eth1[2]
+	-> CheckIP6Header(OFFSET 14)
+	-> CheckBIERin6Header
+	-> CheckBIERHeader
+	-> IP6Print(CONTENTS true)
+	-> Strip(14)
+	-> Print
+	-> bift0;
+
+bift0[0] -> Print("drop") -> Discard;
+bift0[1] -> Print("lo") -> lo_out;
+bift0[2] -> [0] eth0_nds [0] -> eth0_out;
+bift0[3] -> [0] eth1_nds [0] -> eth1_out;

--- a/bier-ospfv3/click/r5.click
+++ b/bier-ospfv3/click/r5.click
@@ -1,0 +1,39 @@
+cfg :: HTTPServer;
+
+bift0 :: LookupBierTable(BIFT_ID 0x01234, BFR_ID 6, IFACE eth0:2, IFACE eth1:3);
+
+lo :: FromDevice(lo, SNIFFER false, PROMISC true);
+eth0 :: FromDevice(eth0, SNIFFER false, PROMISC true);
+eth1 :: FromDevice(eth1, SNIFFER false, PROMISC true);
+lo_out :: Queue -> ToDevice(lo);
+eth0_out :: Queue -> ToDevice(eth0);
+eth1_out :: Queue -> ToDevice(eth1);
+
+eth0_nds :: IP6NDSolicitor(fc00::5, aa:c1:ab:07:ba:0d);
+ndadv_eth0 :: IP6NDAdvertiser(fc00::5/128 aa:c1:ab:07:ba:0d);
+eth1_nds :: IP6NDSolicitor(fc00::5, aa:c1:ab:07:ba:0e);
+ndadv_eth1 :: IP6NDAdvertiser(fc00::5/128 aa:c1:ab:07:ba:0e);
+
+eth0 -> ndp_cl_eth0 :: Classifier(12/86dd 20/3aff 54/87, 12/86dd 20/3aff 54/88, 12/86dd);
+// Received NDP Solicitation, reply with NDP Advertisement
+ndp_cl_eth0[0] -> ndadv_eth0 -> eth0_out;
+// Received NDP Advertisement, save the mapping
+ndp_cl_eth0[1] -> [1] eth0_nds;
+
+eth1 -> ndp_cl_eth1 :: Classifier(12/86dd 20/3aff 54/87, 12/86dd 20/3aff 54/88, 12/86dd);
+ndp_cl_eth1[0] -> ndadv_eth1 -> eth1_out;
+ndp_cl_eth1[1] -> [1] eth1_nds;
+
+lo, ndp_cl_eth0[2], ndp_cl_eth1[2]
+	-> CheckIP6Header(OFFSET 14)
+	-> CheckBIERin6Header
+	-> CheckBIERHeader
+	-> IP6Print(CONTENTS true)
+	-> Strip(14)
+	-> Print
+	-> bift0;
+
+bift0[0] -> Print("drop") -> Discard;
+bift0[1] -> Print("lo") -> lo_out;
+bift0[2] -> [0] eth0_nds [0] -> eth0_out;
+bift0[3] -> [0] eth1_nds [0] -> eth1_out;

--- a/bier-ospfv3/holo/holod.toml
+++ b/bier-ospfv3/holo/holod.toml
@@ -1,0 +1,49 @@
+# User and group information
+user = "holo"
+group = "holo"
+
+# Path to the non-volatile memory storage for configuration transactions,
+# graceful-restart information, authentication sequence numbers, and more.
+#
+# Needs to be writable by @user or @group.
+database_path = "/var/run/holo/holo.db"
+
+# Logging configuration
+[logging]
+  # Logging to journald
+  [logging.journald]
+    # Enable or disable
+    enabled = false
+
+  # # Logging to a file
+  [logging.file]
+  # Enable or disable
+    enabled = false
+  #   # File path (needs to be writable by @user or @group)
+    # dir = "/var/log/"
+  #   # File name
+  #   name = "holod.log"
+  #   # Log rotation (options: "never", "daily", "hourly")
+  #   rotation = "never"
+  #   # Logging style (options: "full", "compact", "pretty", "json")
+  #   style = "full"
+  #   # Enable or disable ANSI terminal colors
+  #   colors = false
+  #   # Sets whether or not the thread ID of the current thread is displayed
+  #   show_thread_id = false
+  #   # Sets whether or not an event’s source code file path and line number are displayed
+  #   show_source = false
+
+  # Logging to the standard output
+  [logging.stdout]
+    # Enable or disable
+    enabled = true
+    # Logging style (options: "full", "compact", "pretty", "json")
+    style = "full"
+    # Enable or disable ANSI terminal colors
+    colors = false
+    # Sets whether or not the thread ID of the current thread is displayed
+    show_thread_id = false
+    # Sets whether or not an event’s source code file path and line number are displayed
+    show_source = false
+

--- a/bier-ospfv3/holo/r0.conf
+++ b/bier-ospfv3/holo/r0.conf
@@ -1,0 +1,49 @@
+interfaces interface lo
+ type iana-if-type:ethernetCsmacd
+ ipv6 address fc00::
+  prefix-length 128
+!
+interfaces interface eth0
+ type iana-if-type:ethernetCsmacd
+ ipv6
+!
+interfaces interface eth1
+ type iana-if-type:ethernetCsmacd
+ ipv6
+!
+routing bier sub-domain 0 ipv6
+ bfr-id 1
+ bfr-prefix fc00::/128
+ underlay-protocol-type OSPF
+ mt-id 0
+ bsl 256-bit
+ igp-algorithm 0
+ bier-algorithm 0
+ load-balance-num 0
+ encapsulation 256-bit bier-encapsulation-ipv6
+  max-si 128
+  in-bift-id in-bift-id-encoding true
+!
+routing control-plane-protocols control-plane-protocol ietf-ospf:ospfv3 main
+ ospf explicit-router-id 0.0.0.1
+ ospf extended-lsa-support true
+ ospf graceful-restart helper-enabled true
+ ospf bier mt-id 0
+ ospf bier bier enable true
+ ospf bier bier advertise true
+ ospf bier bier receive true
+ !
+ ospf areas area 0.0.0.0
+  !
+  interfaces interface lo
+  !
+  interfaces interface eth0
+   interface-type point-to-point
+   hello-interval 5
+   dead-interval 6
+  !
+  interfaces interface eth1
+   interface-type point-to-point
+   hello-interval 5
+   dead-interval 6
+   cost 100

--- a/bier-ospfv3/holo/r1.conf
+++ b/bier-ospfv3/holo/r1.conf
@@ -1,0 +1,66 @@
+interfaces interface lo
+ type iana-if-type:ethernetCsmacd
+ ipv6 address fc00::1
+  prefix-length 128
+!
+interfaces interface eth0
+ type iana-if-type:ethernetCsmacd
+ ipv6
+!
+interfaces interface eth1
+ type iana-if-type:ethernetCsmacd
+ ipv6
+!
+interfaces interface eth2
+ type iana-if-type:ethernetCsmacd
+ ipv6
+!
+interfaces interface eth3
+ type iana-if-type:ethernetCsmacd
+ ipv6
+!
+routing bier sub-domain 0 ipv6
+ bfr-id 2
+ bfr-prefix fc00::1/128
+ underlay-protocol-type OSPF
+ mt-id 0
+ bsl 256-bit
+ igp-algorithm 0
+ bier-algorithm 0
+ load-balance-num 0
+ encapsulation 256-bit bier-encapsulation-ipv6
+  max-si 128
+  in-bift-id in-bift-id-encoding true
+!
+routing control-plane-protocols control-plane-protocol ietf-ospf:ospfv3 main
+ ospf explicit-router-id 0.0.0.2
+ ospf extended-lsa-support true
+ ospf graceful-restart helper-enabled true
+ ospf bier mt-id 0
+ ospf bier bier enable true
+ ospf bier bier advertise true
+ ospf bier bier receive true
+ ospf areas area 0.0.0.0
+  !
+  interfaces interface lo
+  !
+  interfaces interface eth0
+   interface-type point-to-point
+   hello-interval 5
+   dead-interval 6
+  !
+  interfaces interface eth1
+   interface-type point-to-point
+   hello-interval 5
+   dead-interval 6
+  !
+  interfaces interface eth2
+   interface-type point-to-point
+   hello-interval 5
+   dead-interval 6
+   cost 100
+  !
+  interfaces interface eth3
+   interface-type point-to-point
+   hello-interval 5
+   dead-interval 6

--- a/bier-ospfv3/holo/r2.conf
+++ b/bier-ospfv3/holo/r2.conf
@@ -1,0 +1,67 @@
+interfaces interface lo
+ type iana-if-type:ethernetCsmacd
+ ipv6 address fc00::2
+  prefix-length 128
+!
+interfaces interface eth0
+ type iana-if-type:ethernetCsmacd
+ ipv6
+!
+interfaces interface eth1
+ type iana-if-type:ethernetCsmacd
+ ipv6
+!
+interfaces interface eth2
+ type iana-if-type:ethernetCsmacd
+ ipv6
+!
+interfaces interface eth3
+ type iana-if-type:ethernetCsmacd
+ ipv6
+!
+routing bier sub-domain 0 ipv6
+ bfr-id 3
+ bfr-prefix fc00::2/128
+ underlay-protocol-type OSPF
+ mt-id 0
+ bsl 256-bit
+ igp-algorithm 0
+ bier-algorithm 0
+ load-balance-num 0
+ encapsulation 256-bit bier-encapsulation-ipv6
+  max-si 128
+  in-bift-id in-bift-id-encoding true
+!
+routing control-plane-protocols control-plane-protocol ietf-ospf:ospfv3 main
+ ospf explicit-router-id 0.0.0.3
+ ospf extended-lsa-support true
+ ospf graceful-restart helper-enabled true
+ ospf bier mt-id 0
+ ospf bier bier enable true
+ ospf bier bier advertise true
+ ospf bier bier receive true
+ !
+ ospf areas area 0.0.0.0
+  !
+  interfaces interface lo
+  !
+  interfaces interface eth0
+   interface-type point-to-point
+   hello-interval 5
+   dead-interval 6
+   cost 100
+  !
+  interfaces interface eth1
+   interface-type point-to-point
+   hello-interval 5
+   dead-interval 6
+  !
+  interfaces interface eth2
+   interface-type point-to-point
+   hello-interval 5
+   dead-interval 6
+  !
+  interfaces interface eth3
+   interface-type point-to-point
+   hello-interval 5
+   dead-interval 6

--- a/bier-ospfv3/holo/r3.conf
+++ b/bier-ospfv3/holo/r3.conf
@@ -1,0 +1,48 @@
+interfaces interface lo
+ type iana-if-type:ethernetCsmacd
+ ipv6 address fc00::3
+  prefix-length 128
+!
+interfaces interface eth0
+ type iana-if-type:ethernetCsmacd
+ ipv6
+!
+interfaces interface eth1
+ type iana-if-type:ethernetCsmacd
+ ipv6
+!
+routing bier sub-domain 0 ipv6
+ bfr-id 4
+ bfr-prefix fc00::3/128
+ underlay-protocol-type OSPF
+ mt-id 0
+ bsl 256-bit
+ igp-algorithm 0
+ bier-algorithm 0
+ load-balance-num 0
+ encapsulation 256-bit bier-encapsulation-ipv6
+  max-si 128
+  in-bift-id in-bift-id-encoding true
+!
+routing control-plane-protocols control-plane-protocol ietf-ospf:ospfv3 main
+ ospf explicit-router-id 0.0.0.4
+ ospf extended-lsa-support true
+ ospf graceful-restart helper-enabled true
+ ospf bier mt-id 0
+ ospf bier bier enable true
+ ospf bier bier advertise true
+ ospf bier bier receive true
+ !
+ ospf areas area 0.0.0.0
+  !
+  interfaces interface lo
+  !
+  interfaces interface eth0
+   interface-type point-to-point
+   hello-interval 5
+   dead-interval 6
+  !
+  interfaces interface eth1
+   interface-type point-to-point
+   hello-interval 5
+   dead-interval 6

--- a/bier-ospfv3/holo/r4.conf
+++ b/bier-ospfv3/holo/r4.conf
@@ -1,0 +1,49 @@
+interfaces interface lo
+ type iana-if-type:ethernetCsmacd
+ ipv6 address fc00::4
+  prefix-length 128
+!
+interfaces interface eth0
+ type iana-if-type:ethernetCsmacd
+ ipv6
+!
+interfaces interface eth1
+ type iana-if-type:ethernetCsmacd
+ ipv6
+!
+routing bier sub-domain 0 ipv6
+ bfr-id 5
+ bfr-prefix fc00::4/128
+ underlay-protocol-type OSPF
+ mt-id 0
+ bsl 256-bit
+ igp-algorithm 0
+ bier-algorithm 0
+ load-balance-num 0
+ encapsulation 256-bit bier-encapsulation-ipv6
+  max-si 128
+  in-bift-id in-bift-id-encoding true
+!
+routing control-plane-protocols control-plane-protocol ietf-ospf:ospfv3 main
+ ospf explicit-router-id 0.0.0.5
+ ospf extended-lsa-support true
+ ospf graceful-restart helper-enabled true
+ ospf bier mt-id 0
+ ospf bier bier enable true
+ ospf bier bier advertise true
+ ospf bier bier receive true
+ !
+ ospf areas area 0.0.0.0
+  !
+  interfaces interface lo
+  !
+  interfaces interface eth0
+   interface-type point-to-point
+   hello-interval 5
+   dead-interval 6
+   cost 100
+  !
+  interfaces interface eth1
+   interface-type point-to-point
+   hello-interval 5
+   dead-interval 6

--- a/bier-ospfv3/holo/r5.conf
+++ b/bier-ospfv3/holo/r5.conf
@@ -1,0 +1,48 @@
+interfaces interface lo
+ type iana-if-type:ethernetCsmacd
+ ipv6 address fc00::5
+  prefix-length 128
+!
+interfaces interface eth0
+ type iana-if-type:ethernetCsmacd
+ ipv6
+!
+interfaces interface eth1
+ type iana-if-type:ethernetCsmacd
+ ipv6
+!
+routing bier sub-domain 0 ipv6
+ bfr-id 6
+ bfr-prefix fc00::5/128
+ underlay-protocol-type OSPF
+ mt-id 0
+ bsl 256-bit
+ igp-algorithm 0
+ bier-algorithm 0
+ load-balance-num 0
+ encapsulation 256-bit bier-encapsulation-ipv6
+  max-si 128
+  in-bift-id in-bift-id-encoding true
+!
+routing control-plane-protocols control-plane-protocol ietf-ospf:ospfv3 main
+ ospf explicit-router-id 0.0.0.6
+ ospf extended-lsa-support true
+ ospf graceful-restart helper-enabled true
+ ospf bier mt-id 0
+ ospf bier bier enable true
+ ospf bier bier advertise true
+ ospf bier bier receive true
+ !
+ ospf areas area 0.0.0.0
+  !
+  interfaces interface lo
+  !
+  interfaces interface eth0
+   interface-type point-to-point
+   hello-interval 5
+   dead-interval 6
+  !
+  interfaces interface eth1
+   interface-type point-to-point
+   hello-interval 5
+   dead-interval 6

--- a/bier-ospfv3/topology.yml
+++ b/bier-ospfv3/topology.yml
@@ -1,0 +1,116 @@
+#
+#            +---------+
+#            |         |
+#            |   R00   |
+#       eth0 | 0.0.0.1 | eth1
+#      +-----+         +-----+
+#      |     +---------+     | metric=100
+#      |                     |
+#      | eth0                | eth0
+# +----+----+           +----+----+
+# |         |           |         |
+# |   R01   | eth1      |   R02   |
+# | 0.0.0.2 +-----------+ 0.0.0.3 |
+# |         |      eth1 |         |
+# +----+--+-+           +-+--+----+
+# eth3 |  | eth2     eth2 |  | eth3
+#      |  | metric=100    |  |
+#      |  |  +---------+  |  |
+#      |  |  |         |  |  |
+#      |  +--+   R04   +--+  |
+#      | eth0| 0.0.0.5 |eth1 |
+#      |     |         |     |
+#      |     +---------+     |
+#      |                     |
+#      | eth0           eth0 |
+# +----+----+           +----+----+
+# |         |           |         |
+# |   R03   | eth1      |   R05   |
+# | 0.0.0.4 +-----------+ 0.0.0.6 |
+# |         |      eth1 |         |
+# +---------+           +---------+
+# 
+
+name: bier-ospfv3
+
+topology:
+
+  defaults:
+    kind: linux
+    image: holo-runner
+    network-mode: none
+    sysctls:
+      net.ipv6.conf.all.forwarding: 1
+    exec:
+      # Launch click dataplane process
+      - sh -c "click /etc/bier.click > /tmp/click.log 2>&1 &"
+      - sh -c "tshark -ni any -w /tmp/cap.pcap &"
+      - sh -c "sleep 2 && holo-cli --file /etc/holo/holo.conf"
+    binds:
+      # - ../bier_pkt/target/debug/bier_pkt:/usr/bin/bier_pkt
+      - holo/holod.toml:/etc/holo/holod.toml
+
+  nodes: 
+
+    r0:
+      binds:
+        - holo/r0.conf:/etc/holo/holo.conf
+        - click/r0.click:/etc/bier.click
+      exec:
+        - ip l set eth0 address aa:c1:ab:07:ba:00
+        - ip l set eth1 address aa:c1:ab:07:ba:01
+
+    r1:
+      binds:
+        - holo/r1.conf:/etc/holo/holo.conf
+        - click/r1.click:/etc/bier.click
+      exec:
+        - ip l set eth0 address aa:c1:ab:07:ba:02
+        - ip l set eth1 address aa:c1:ab:07:ba:03
+        - ip l set eth2 address aa:c1:ab:07:ba:04
+        - ip l set eth3 address aa:c1:ab:07:ba:05
+
+    r2:
+      binds:
+        - holo/r2.conf:/etc/holo/holo.conf
+        - click/r2.click:/etc/bier.click
+      exec:
+        - ip l set eth0 address aa:c1:ab:07:ba:06
+        - ip l set eth1 address aa:c1:ab:07:ba:07
+        - ip l set eth2 address aa:c1:ab:07:ba:08
+        - ip l set eth3 address aa:c1:ab:07:ba:09
+
+    r3:
+      binds:
+        - holo/r3.conf:/etc/holo/holo.conf
+        - click/r3.click:/etc/bier.click
+      exec:
+        - ip l set eth0 address aa:c1:ab:07:ba:0a
+        - ip l set eth1 address aa:c1:ab:07:ba:0b
+
+    r4:
+      binds:
+        - holo/r4.conf:/etc/holo/holo.conf
+        - click/r4.click:/etc/bier.click
+      exec:
+        - ip l set eth0 address aa:c1:ab:07:ba:0c
+        - ip l set eth1 address aa:c1:ab:07:ba:0d
+
+    r5:
+      binds:
+        - holo/r5.conf:/etc/holo/holo.conf
+        - click/r5.click:/etc/bier.click
+      exec:
+        - ip l set eth0 address aa:c1:ab:07:ba:0e
+        - ip l set eth1 address aa:c1:ab:07:ba:0f
+        
+  links:
+    - endpoints: ["r0:eth0", "r1:eth0"]
+    - endpoints: ["r0:eth1", "r2:eth0"]
+    - endpoints: ["r1:eth1", "r2:eth1"]
+    - endpoints: ["r1:eth2", "r4:eth0"]
+    - endpoints: ["r2:eth2", "r4:eth1"]
+    - endpoints: ["r1:eth3", "r3:eth0"]
+    - endpoints: ["r2:eth3", "r5:eth0"]
+    - endpoints: ["r3:eth1", "r5:eth1"]
+  


### PR DESCRIPTION
This PR adds a sample topology deploying the BIER control-plane via OSPFv3 and a BIER data-plane implemented with the [FastClick](https://github.com/tbarbette/fastclick) framework.