### PR TITLE
bgp: add local routes to redistributes

### DIFF
--- a/bgp/holo/rt1.conf
+++ b/bgp/holo/rt1.conf
@@ -58,13 +58,15 @@ routing control-plane-protocols control-plane-protocol ietf-bgp:bgp main
   !
  !
 !
-routing-policy defined-sets prefix-sets prefix-set LOOPBACK ipv4
+routing-policy defined-sets prefix-sets prefix-set LOCAL ipv4
  !
  prefixes prefix-list 1.1.1.1/32 32 32
+ prefixes prefix-list 10.0.2.0/24 24 24
+ prefixes prefix-list 10.0.1.0/24 24 24
 !
 routing-policy policy-definitions policy-definition REDIST
  !
  statements statement 1
-  conditions match-prefix-set prefix-set LOOPBACK
+  conditions match-prefix-set prefix-set LOCAL
   actions policy-result accept-route
 !

--- a/bgp/holo/rt2.conf
+++ b/bgp/holo/rt2.conf
@@ -58,13 +58,15 @@ routing control-plane-protocols control-plane-protocol ietf-bgp:bgp main
   !
  !
 !
-routing-policy defined-sets prefix-sets prefix-set LOOPBACK ipv4
+routing-policy defined-sets prefix-sets prefix-set LOCAL ipv4
  !
  prefixes prefix-list 2.2.2.2/32 32 32
+ prefixes prefix-list 10.0.1.0/24 24 24
+ prefixes prefix-list 10.0.3.0/24 24 24
 !
 routing-policy policy-definitions policy-definition REDIST
  !
  statements statement 1
-  conditions match-prefix-set prefix-set LOOPBACK
+  conditions match-prefix-set prefix-set LOCAL
   actions policy-result accept-route
 !

--- a/bgp/holo/rt3.conf
+++ b/bgp/holo/rt3.conf
@@ -71,13 +71,19 @@ routing control-plane-protocols control-plane-protocol ietf-bgp:bgp main
   !
  !
 !
-routing-policy defined-sets prefix-sets prefix-set LOOPBACK ipv4
+routing-policy defined-sets prefix-sets prefix-set LOCAL ipv4
  !
  prefixes prefix-list 3.3.3.3/32 32 32
+ prefixes prefix-list 10.0.2.0/24 24 24
 !
 routing-policy policy-definitions policy-definition REDIST
  !
- statements statement 1
-  conditions match-prefix-set prefix-set LOOPBACK
+ statements statement LOCAL
+  conditions match-prefix-set prefix-set LOCAL
   actions policy-result accept-route
+ !
+ statements statement OSPF
+  conditions source-route ietf-ospf:ospfv2
+  actions policy-result accept-route
+ !
 !

--- a/bgp/holo/rt4.conf
+++ b/bgp/holo/rt4.conf
@@ -71,13 +71,19 @@ routing control-plane-protocols control-plane-protocol ietf-bgp:bgp main
   !
  !
 !
-routing-policy defined-sets prefix-sets prefix-set LOOPBACK ipv4
+routing-policy defined-sets prefix-sets prefix-set LOCAL ipv4
  !
  prefixes prefix-list 4.4.4.4/32 32 32
+ prefixes prefix-list 10.0.3.0/24 24 24
 !
 routing-policy policy-definitions policy-definition REDIST
  !
- statements statement 1
-  conditions match-prefix-set prefix-set LOOPBACK
+ statements statement LOCAL
+  conditions match-prefix-set prefix-set LOCAL
   actions policy-result accept-route
+ !
+ statements statement OSPF
+  conditions source-route ietf-ospf:ospfv2
+  actions policy-result accept-route
+ !
 !


### PR DESCRIPTION
Add local networks(apart from Localhost) to those to be redistributed.

Makes the IPs reachable (including the LOOPBACK IPs)